### PR TITLE
Updating CanonURL.php using SetCanonicalUrl

### DIFF
--- a/CanonURL.php
+++ b/CanonURL.php
@@ -35,11 +35,6 @@
 	global $wgHooks;
 	$wgHooks['BeforePageDisplay'][]  = 'CanonURL';
 	function CanonURL( $out ) {
-		if ( $out->getRedirect() == '' ) {
-			$out->setCanonicalUrl( htmlspecialchars( $out->getTitle()->getCanonicalURL() ) );
-			return true;
-		} else {
-			$out->setCanonicalUrl( htmlspecialchars(  $out->getRedirect() ) );
-			return true;
-		}
+		$out->setCanonicalUrl( $out->getTitle()->escapeCanonicalURL() );
+		return true;
 }

--- a/CanonURL.php
+++ b/CanonURL.php
@@ -36,8 +36,6 @@
 	$wgHooks['BeforePageDisplay'][]  = 'CanonURL';
 	function CanonURL($out)
 	{
-		$out->setCanonicalUrl( htmlspecialchars( $out->getTitle()->getCanonicalURL())
-
-	);	 
-	return true;
+		$out -> setCanonicalUrl($out->getTitle()->getCanonicalURL());
+		return true;
 }

--- a/CanonURL.php
+++ b/CanonURL.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 /**
  * Initialization file for the CanonURL extension.
@@ -13,14 +13,14 @@
  * @licence GNU GPL v3
  *
  * @author Abhi M Balakrishnan http://www.mediawiki.org/wiki/User:Abhi_M_Balakrishnan with the help of Timo Tijhof (http://www.mediawiki.org/wiki/User:Krinkle)
- */ 
+ */
 	if ( !defined( 'MEDIAWIKI' ) ) {
 		echo( "This file is an extension to the MediaWiki software and cannot be used standalone.\n" );
 		die( 1 );
 	}
-	
+
 	define( 'CanonURL_VERSION', '0.5' );
-	
+
 	$wgExtensionCredits['other'][] = array(
 		'path' => __FILE__,
 		'name' => 'CanonURL',
@@ -29,12 +29,12 @@
 		'url' => 'https://mediawiki.org/wiki/Extension:CanonURL',
 		'descriptionmsg' => 'canonurl-desc',
 	);
-	
+
 	$wgExtensionMessagesFiles['CanonURL'] = dirname( __FILE__ ) . '/CanonURL.i18n.php';
-	 
+
 	global $wgHooks;
 	$wgHooks['BeforePageDisplay'][]  = 'CanonURL';
-	function CanonURL($out)
+	function CanonURL( $out )
 	{
 		if ( $out->getRedirect() == '' )
 		{

--- a/CanonURL.php
+++ b/CanonURL.php
@@ -36,6 +36,14 @@
 	$wgHooks['BeforePageDisplay'][]  = 'CanonURL';
 	function CanonURL($out)
 	{
-		$out -> setCanonicalUrl($out->getTitle()->getCanonicalURL());
-		return true;
+		if ($out -> getRedirect() == '')
+		{
+			$out -> setCanonicalUrl($out->getTitle()->getCanonicalURL());
+			return true;
+		}
+		else
+		{
+			$out -> setCanonicalUrl($out->getRedirect());
+			return true;
+		}
 }

--- a/CanonURL.php
+++ b/CanonURL.php
@@ -36,8 +36,7 @@
 	$wgHooks['BeforePageDisplay'][]  = 'CanonURL';
 	function CanonURL($out)
 	{
-		$out->addHeadItem( 'canonical',
-		'<link rel="canonical" href="' . htmlspecialchars( $out->getTitle()->getCanonicalURL()) . '" />' . "\n"
+		$out->setCanonicalUrl( htmlspecialchars( $out->getTitle()->getCanonicalURL())
 
 	);	 
 	return true;

--- a/CanonURL.php
+++ b/CanonURL.php
@@ -19,7 +19,7 @@
 		die( 1 );
 	}
 	
-	define( 'CanonURL_VERSION', '0.3' );
+	define( 'CanonURL_VERSION', '0.5' );
 	
 	$wgExtensionCredits['other'][] = array(
 		'path' => __FILE__,

--- a/CanonURL.php
+++ b/CanonURL.php
@@ -36,14 +36,14 @@
 	$wgHooks['BeforePageDisplay'][]  = 'CanonURL';
 	function CanonURL($out)
 	{
-		if ($out -> getRedirect() == '')
+		if ( $out->getRedirect() == '' )
 		{
-			$out -> setCanonicalUrl($out->getTitle()->getCanonicalURL());
+			$out->setCanonicalUrl( htmlspecialchars( $out->getTitle()->getCanonicalURL() ) );
 			return true;
 		}
 		else
 		{
-			$out -> setCanonicalUrl($out->getRedirect());
+			$out->setCanonicalUrl( htmlspecialchars(  $out->getRedirect() ) );
 			return true;
 		}
 }

--- a/CanonURL.php
+++ b/CanonURL.php
@@ -34,15 +34,11 @@
 
 	global $wgHooks;
 	$wgHooks['BeforePageDisplay'][]  = 'CanonURL';
-	function CanonURL( $out )
-	{
-		if ( $out->getRedirect() == '' )
-		{
+	function CanonURL( $out ) {
+		if ( $out->getRedirect() == '' ) {
 			$out->setCanonicalUrl( htmlspecialchars( $out->getTitle()->getCanonicalURL() ) );
 			return true;
-		}
-		else
-		{
+		} else {
 			$out->setCanonicalUrl( htmlspecialchars(  $out->getRedirect() ) );
 			return true;
 		}

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 --------------------------------------------------------------------------
-README for the CanonURL extension 0.3
+README for the CanonURL extension 0.5
 Licenses: GNU General Public Licence (GPL)
           GNU Free Documentation License (GFDL)
 --------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ CanonURL
 ========
 Adds the canonical links to the head of Mediawiki pages according to Google Canonicalization Content Guidelines
 --------------------------------------------------------------------------
-README for the CanonURL extension 0.3
+README for the CanonURL extension 0.5
 Licenses: GNU General Public Licence (GPL)
           GNU Free Documentation License (GFDL)
 --------------------------------------------------------------------------


### PR DESCRIPTION
Hi, I changed the extension to use "includes/OutputPage.php"'s SetCanonicalUrl(), so it eliminates the need for handwriting the link tag and htmlspecialchars(). No major code changes otherwise.
